### PR TITLE
Configure Maven Central publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,15 @@ The following is brief overview of the utility classes provided by java-core.
 
 ### JSON config loading with config classes / objects
 The [JsonConfigLoader](src/main/java/eu/nordtal/jcore/config/JsonConfigLoader.java) provides methods to load and save JSON config files to and from predefined classes / objects which inherit from [JsonConfig](src/main/java/eu/nordtal/jcore/config/JsonConfig.java). The needed inheritance of JsonConfig is currently redundant, but might be used in the future for new features. The JsonConfigLoader automatically adds and removes new config parameters on load.
+
+## Publishing to Maven Central
+The project is configured to publish signed artifacts to Maven Central via Sonatype. Before running `./gradlew publish` you need to supply the following information via `gradle.properties` (see `gradle.properties.sample`) or environment variables:
+
+```
+sonatype.username=your-sonatype-username-or-token
+sonatype.password=your-sonatype-password-or-token-secret
+signing.key=base64-encoded-GPG-key
+signing.password=gpg-key-passphrase
+```
+
+Generate an access token in the [Sonatype Central Portal](https://central.sonatype.com/) and import/export your GPG key if required. Snapshot deployments use the `SONATYPE_USERNAME` and `SONATYPE_PASSWORD` environment variables when properties are absent.

--- a/README.md
+++ b/README.md
@@ -28,3 +28,38 @@ signing.password=gpg-key-passphrase
 ```
 
 Generate an access token in the [Sonatype Central Portal](https://central.sonatype.com/) and import/export your GPG key if required. Snapshot deployments use the `SONATYPE_USERNAME` and `SONATYPE_PASSWORD` environment variables when properties are absent.
+
+### Generating a GPG signing key
+
+Releases are signed with an OpenPGP (GPG) key. If you have never used one before, follow these steps:
+
+1. **Install GPG** – e.g. `apt install gnupg` or `brew install gpg`. Verify with `gpg --version`.
+2. **Create a key**:
+
+   ```bash
+   gpg --full-generate-key
+   ```
+
+   Choose RSA and a passphrase when prompted.
+3. **Find the key ID**:
+
+   ```bash
+   gpg --list-secret-keys --keyid-format=long
+   ```
+
+4. **Publish the public key** so Maven Central can verify signatures:
+
+   ```bash
+   gpg --keyserver keyserver.ubuntu.com --send-keys <KEY_ID>
+   ```
+
+5. **Export the private key for Gradle** and encode it as a single line:
+
+   ```bash
+   gpg --armor --export-secret-key <KEY_ID> | base64
+   ```
+
+   Put the resulting string into `signing.key` in `gradle.properties`. Use the passphrase you set in step 2 as `signing.password`.
+
+Finally, log in to the Sonatype portal and add the same public key under **Account → Profile → GPG Keys**.
+

--- a/README.md
+++ b/README.md
@@ -16,3 +16,13 @@ The following is brief overview of the utility classes provided by java-core.
 
 ### JSON config loading with config classes / objects
 The [JsonConfigLoader](src/main/java/eu/nordtal/jcore/config/JsonConfigLoader.java) provides methods to load and save JSON config files to and from predefined classes / objects which inherit from [JsonConfig](src/main/java/eu/nordtal/jcore/config/JsonConfig.java). The needed inheritance of JsonConfig is currently redundant, but might be used in the future for new features. The JsonConfigLoader automatically adds and removes new config parameters on load.
+
+## Publishing
+
+To release artifacts to Maven Central you need a public GPG key. Publish your key to a public key server so that Sonatype can retrieve it during artifact validation:
+
+```bash
+gpg --send-keys YOUR_KEY_ID --keyserver keyserver.ubuntu.com
+```
+
+Sonatype automatically fetches keys from public key servers, eliminating any manual upload step.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Base64
+
 plugins {
     id("java")
     id("java-library")
@@ -119,11 +121,15 @@ publishing {
 }
 
 signing {
-    val signingKey = (findProperty("signing.key") as String?) ?: System.getenv("SIGNING_KEY")
-    val signingPassword = (findProperty("signing.password") as String?) ?: System.getenv("SIGNING_PASSWORD")
-    if (signingKey != null && signingPassword != null) {
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign(publishing.publications["mavenJava"])
+    signing {
+        val signingKey = project.findProperty("signing.key") as String?
+        val signingPassword = project.findProperty("signing.password") as String?
+
+        if (signingKey != null && signingPassword != null) {
+            val decodedKey = String(Base64.getDecoder().decode(signingKey))
+            useInMemoryPgpKeys(decodedKey, signingPassword)
+            sign(publishing.publications["mavenJava"])
+        }
     }
 }
 

--- a/gradle.properties.sample
+++ b/gradle.properties.sample
@@ -1,0 +1,7 @@
+# Rename to gradle.properties and replace values with your own before publishing.
+sonatype.username=token
+sonatype.password=token-secret
+
+# ASCII-armored private key for signing (single line with \n literals or multi-line).
+signing.key=
+signing.password=


### PR DESCRIPTION
## Summary
- remove GitHub Packages configuration and set up Maven Central repositories
- sign and publish artifacts with Sonatype-compatible POM metadata
- add sample `gradle.properties` and documentation for publishing

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c720bfe244832785c7ceedf14c5dca