### PR TITLE
Switch to Sonatype token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ The following is brief overview of the utility classes provided by java-core.
 The [JsonConfigLoader](src/main/java/eu/nordtal/jcore/config/JsonConfigLoader.java) provides methods to load and save JSON config files to and from predefined classes / objects which inherit from [JsonConfig](src/main/java/eu/nordtal/jcore/config/JsonConfig.java). The needed inheritance of JsonConfig is currently redundant, but might be used in the future for new features. The JsonConfigLoader automatically adds and removes new config parameters on load.
 
 ## Publishing to Maven Central
-The project is configured to publish signed artifacts to Maven Central via Sonatype. Before running `./gradlew publish` you need to supply the following information via `gradle.properties` (see `gradle.properties.sample`) or environment variables:
+The project is configured to publish signed artifacts to Maven Central via Sonatype.
+Sonatype now requires a token-based `Authorization` header. The build script
+derives the header value by base64 encoding the token's username and password.
+Before running `./gradlew publish` you need to supply the following information
+via `gradle.properties` (see `gradle.properties.sample`) or environment variables:
 
 ```
 sonatype.username=your-sonatype-username-or-token

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 import java.util.Base64
+import org.gradle.api.credentials.HttpHeaderCredentials
+import org.gradle.authentication.http.HttpHeaderAuthentication
 
 plugins {
     id("java")
@@ -69,17 +71,31 @@ publishing {
         maven {
             name = "Sonatype"
             url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-            credentials {
-                username = (project.findProperty("sonatype.username") as String?) ?: System.getenv("SONATYPE_USERNAME")
-                password = (project.findProperty("sonatype.password") as String?) ?: System.getenv("SONATYPE_PASSWORD")
+            credentials(HttpHeaderCredentials::class) {
+                val user = (project.findProperty("sonatype.username") as String?) ?: System.getenv("SONATYPE_USERNAME")
+                val pass = (project.findProperty("sonatype.password") as String?) ?: System.getenv("SONATYPE_PASSWORD")
+                if (user != null && pass != null) {
+                    name = "Authorization"
+                    value = "Bearer " + Base64.getEncoder().encodeToString("$user:$pass".toByteArray())
+                }
+            }
+            authentication {
+                create<HttpHeaderAuthentication>("header")
             }
         }
         maven {
             name = "SonatypeSnapshots"
             url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-            credentials {
-                username = (project.findProperty("sonatype.username") as String?) ?: System.getenv("SONATYPE_USERNAME")
-                password = (project.findProperty("sonatype.password") as String?) ?: System.getenv("SONATYPE_PASSWORD")
+            credentials(HttpHeaderCredentials::class) {
+                val user = (project.findProperty("sonatype.username") as String?) ?: System.getenv("SONATYPE_USERNAME")
+                val pass = (project.findProperty("sonatype.password") as String?) ?: System.getenv("SONATYPE_PASSWORD")
+                if (user != null && pass != null) {
+                    name = "Authorization"
+                    value = "Bearer " + Base64.getEncoder().encodeToString("$user:$pass".toByteArray())
+                }
+            }
+            authentication {
+                create<HttpHeaderAuthentication>("header")
             }
         }
     }

--- a/gradle.properties.sample
+++ b/gradle.properties.sample
@@ -1,4 +1,5 @@
 # Rename to gradle.properties and replace values with your own before publishing.
+# Sonatype user token credentials (see https://central.sonatype.com/)
 sonatype.username=token
 sonatype.password=token-secret
 


### PR DESCRIPTION
## Summary
- use Sonatype token with Authorization header for publishing
- document token usage in README and gradle.properties sample

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c72e3774a4832793ba382a76f903b5